### PR TITLE
Initial commit

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -1,0 +1,37 @@
+# Based off of <https://mozilla.github.io/cargo-vet/multiple-repositories.html>
+name: CI
+on:
+  schedule:
+    # Every hour
+    - cron:  '0 * * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  aggregate:
+    name: Aggregate Dependencies
+    runs-on: ubuntu-latest
+    container: rust:latest
+    env:
+      CARGO_VET_VERSION: 0.8.0
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/cache@v2
+      id: cache-vet
+      with:
+        path: /usr/local/cargo/bin/cargo-vet
+        key: cargo-vet-${{ env.CARGO_VET_VERSION }}
+    - name: Install the cargo-vet binary, if needed
+      if: ${{ steps.cache-vet.outputs.cache-hit != 'true' }}
+      run: cargo install --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+    - name: Invoke cargo-vet aggregate
+      run: cargo vet aggregate --output-file audits.toml sources.list
+    - name: Commit changes (if any)
+      run: |
+        git config --global user.name "cargo-vet[bot]"
+        git config --global user.email "cargo-vet-aggregate@invalid"
+        git add audits.toml
+        git commit -m "Aggregate new audits" || true
+    - name: Push changes (if any)
+      run: git push origin main

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# securedrop-supply-chain
-Aggregated audits for Rust crates by SecureDrop 
+# SecureDrop's Rust crate audits
+
+SecureDrop uses [cargo-vet](https://mozilla.github.io/cargo-vet/index.html)
+to ensure third-party Rust dependencies have been audited  by us or another trusted entity (e.g. [Mozilla](https://github.com/mozilla/supply-chain));
+see [our documentation](https://developers.securedrop.org/en/latest/dependency_updates.html#auditing-rust-dependencies)
+for more details.
+
+This repository automatically [aggregates](https://mozilla.github.io/cargo-vet/multiple-repositories.html)
+our audits from various repositories to make them easily reusable by others.
+
+To import our audits into another cargo-vet instance, add the following
+lines to your config.toml:
+```toml
+[imports.securedrop]
+url = "https://raw.githubusercontent.com/freedomofpress/securedrop-supply-chain/main/audits.toml"
+```

--- a/sources.list
+++ b/sources.list
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/freedomofpress/securedrop/develop/supply-chain/audits.toml


### PR DESCRIPTION
Set up this repository to aggregate cargo-vet audits from multiple repositories as described at <https://mozilla.github.io/cargo-vet/multiple-repositories.html>.

We currently just have the SecureDrop server repository, but soon we'll have Rust code in the proxy too.

Refs https://github.com/freedomofpress/securedrop-client/issues/1678.

## Test plan
* [x] Visual review
* [x] Check this out, run `cargo vet aggregate --output-file audits.toml sources.list` and see the audits.toml it spits out looks good. (Intentionally not committed so we'll see CI run and add it within an hour of merging.)