### PR TITLE
Upgrade to cargo-vet 0.10.0

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container: rust:latest
     env:
-      CARGO_VET_VERSION: 0.9.0
+      CARGO_VET_VERSION: 0.10.0
     steps:
     - uses: actions/checkout@master
     - uses: actions/cache@v4


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-tooling/issues/17>.

## Test plan

* [x] visual review
